### PR TITLE
Add composeDropOne benchmark.

### DIFF
--- a/Benchmarks.hs
+++ b/Benchmarks.hs
@@ -76,6 +76,7 @@ main = do
       , $(createBgroup "map-with-all-in-filter" "composeMapAllInFilter")
       , $(createBgroup "all-in-filters" "composeAllInFilters")
       , $(createBgroup "all-out-filters" "composeAllOutFilters")
+      , $(createBgroup "drop-one" "composeDropOne")
       ]
     -- XXX Disabling this for now to reduce the running time
     -- We need a way to include/exclude this dynamically

--- a/Benchmarks/Conduit.hs
+++ b/Benchmarks/Conduit.hs
@@ -45,7 +45,7 @@ import qualified Data.Conduit.List as SL
 toNull, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Source m () Int -> m ()
 
@@ -139,6 +139,7 @@ composeMapM           = compose (S.mapM return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.map (subtract 1) S..| S.filter (<= maxValue))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Source m () Int -> m ()
 composeScaling m =

--- a/Benchmarks/Drinkery.hs
+++ b/Benchmarks/Drinkery.hs
@@ -38,7 +38,7 @@ import qualified Data.Drinkery.Finite as S
 toNull, toList, foldl, last, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Source m () Int -> m ()
 
@@ -112,6 +112,7 @@ composeMapM           = compose (S.traverse return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.map (subtract 1) S.++$ S.filter (<= maxValue))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Source m () Int -> m ()
 composeScaling m =

--- a/Benchmarks/List.hs
+++ b/Benchmarks/List.hs
@@ -40,7 +40,7 @@ import qualified Data.List          as S
 toNull, toList, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: [Int] -> [Int]
 
 foldl :: [Int] -> Int
@@ -102,6 +102,7 @@ composeMapM           = compose (S.map (+1))
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.filter (<= maxValue) . S.map (subtract 1))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Int -> [Int] -> [Int]
 composeScaling m =

--- a/Benchmarks/ListT.hs
+++ b/Benchmarks/ListT.hs
@@ -23,7 +23,7 @@ import qualified ListT as S
 toNull, toList, foldl, last, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Int -> m ()
 
@@ -88,6 +88,7 @@ composeMapM           = compose (lift . return)
 composeAllInFilters   = compose undefined
 composeAllOutFilters  = compose undefined
 composeMapAllInFilter = compose undefined
+composeDropOne        = compose undefined
 
 composeScaling :: Monad m => Int -> Int -> m ()
 composeScaling m n =

--- a/Benchmarks/ListTransformer.hs
+++ b/Benchmarks/ListTransformer.hs
@@ -23,7 +23,7 @@ import qualified List.Transformer as S
 toNull, toList, foldl, last, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Int -> m ()
 
@@ -88,6 +88,7 @@ composeMapM           = compose (lift . return)
 composeAllInFilters   = compose undefined
 composeAllOutFilters  = compose undefined
 composeMapAllInFilter = compose undefined
+composeDropOne        = compose undefined
 
 composeScaling :: Monad m => Int -> Int -> m ()
 composeScaling m n =

--- a/Benchmarks/LogicT.hs
+++ b/Benchmarks/LogicT.hs
@@ -23,7 +23,7 @@ import qualified Data.List as List
 toNull, toList, foldl, last, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Int -> m ()
 
@@ -88,6 +88,7 @@ composeMapM           = compose (S.lift . return)
 composeAllInFilters   = compose undefined
 composeAllOutFilters  = compose undefined
 composeMapAllInFilter = compose undefined
+composeDropOne        = compose undefined
 
 composeScaling :: Monad m => Int -> Int -> m ()
 composeScaling m n =

--- a/Benchmarks/Machines.hs
+++ b/Benchmarks/Machines.hs
@@ -44,7 +44,7 @@ import qualified Data.Machine      as S
 toNull, foldl, last, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => S.MachineT m k Int -> m ()
 
@@ -117,6 +117,7 @@ composeMapM           = compose (S.autoM return)
 composeAllInFilters   = compose (S.filtered (<= maxValue))
 composeAllOutFilters  = compose (S.filtered (> maxValue))
 composeMapAllInFilter = compose (S.mapping (subtract 1) S.~> S.filtered (<= maxValue))
+composeDropOne        = compose (S.dropping 1)
 
 composeScaling :: Monad m => Int -> Source m Int -> m ()
 composeScaling m =

--- a/Benchmarks/Pipes.hs
+++ b/Benchmarks/Pipes.hs
@@ -46,7 +46,7 @@ import qualified Pipes.Prelude     as S
 toNull, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Source m () Int -> m ()
 
@@ -128,6 +128,7 @@ composeMapM           = compose (S.mapM return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.map (subtract 1) S.>-> S.filter (<= maxValue))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Source m () Int -> m ()
 composeScaling m =

--- a/Benchmarks/Streaming.hs
+++ b/Benchmarks/Streaming.hs
@@ -46,7 +46,7 @@ import qualified Streaming.Prelude as S
 toNull, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Stream m Int -> m ()
 
@@ -135,6 +135,7 @@ composeMapM           = compose (S.mapM return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.filter (<= maxValue) . S.map (subtract 1))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Stream m Int -> m ()
 composeScaling m =

--- a/Benchmarks/Streamly.hs
+++ b/Benchmarks/Streamly.hs
@@ -45,7 +45,7 @@ import qualified Streamly.Prelude  as S
 toNull, scan, map, filterEven, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Stream m Int -> m ()
 
@@ -155,6 +155,7 @@ composeMapM           = compose (S.mapM return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.filter (<= maxValue) . fmap (subtract 1))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Stream m Int -> m ()
 composeScaling m =

--- a/Benchmarks/Vector.hs
+++ b/Benchmarks/Vector.hs
@@ -44,7 +44,7 @@ import qualified Data.Vector.Fusion.Stream.Monadic as S
 toNull, scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue, zip,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: Monad m
     => Stream m Int -> m ()
 
@@ -153,6 +153,7 @@ composeMapM           = compose (S.mapM return)
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.filter (<= maxValue) . S.map (subtract 1))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Monad m => Int -> Stream m Int -> m ()
 composeScaling n =

--- a/Benchmarks/VectorPure.hs
+++ b/Benchmarks/VectorPure.hs
@@ -40,7 +40,7 @@ import qualified Data.Vector as S
 scan, map, filterEven, mapM, filterAllOut,
     filterAllIn, takeOne, takeAll, takeWhileTrue, dropAll, dropWhileTrue,
     concat, composeMapM, composeAllInFilters, composeAllOutFilters,
-    composeMapAllInFilter
+    composeMapAllInFilter, composeDropOne
     :: S.Vector Int -> S.Vector Int
 
 toNull :: S.Vector Int -> [Int]
@@ -104,6 +104,7 @@ composeMapM           = compose (S.map (+1))
 composeAllInFilters   = compose (S.filter (<= maxValue))
 composeAllOutFilters  = compose (S.filter (> maxValue))
 composeMapAllInFilter = compose (S.filter (<= maxValue) . S.map (subtract 1))
+composeDropOne        = compose (S.drop 1)
 
 composeScaling :: Int -> S.Vector Int -> S.Vector Int
 composeScaling m =

--- a/Charts.hs
+++ b/Charts.hs
@@ -62,6 +62,7 @@ charts =
       , [ "compose/mapM"
         , "compose/all-in-filters"
         , "compose/map-with-all-in-filter"
+        , "compose/drop-one"
         ]
       )
     ]


### PR DESCRIPTION
I added a benchmark that should demonstrate runtime quadratic in the number of consecutive `drop`s in `streamly`. Since your `Stream` type is recursive and your `drop` function is recursive anyway, I do believe this is fixable, by repeatetly using `uncons`. To my surprise, `vector` has the same "problem" and I think it is on purpose to make `drop` non-recursive, to make it fuse.